### PR TITLE
Change the VC storage from SortedVecMap to AvlTreeMap

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,13 +128,14 @@ pub fn upload_vc_callback(
         .unwrap_or_else(|| panic!("No VC map for issuer {}", issuer_did));
         
         vcs_map.insert(state.next_vc_id, new_vc);
+        state.vcs.insert(issuer_did, vcs_map);
 
     } else {
         let mut vcs_map : SortedVecMap<u128, VC> = SortedVecMap::new();
         vcs_map.insert(state.next_vc_id, new_vc);
+        state.vcs.insert(issuer_did, vcs_map);
     }
-    
-    state.vcs.insert(issuer_did, vcs_map);
+
     state.next_vc_id += 1;
 
     (state, vec![])

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,16 +122,19 @@ pub fn upload_vc_callback(
     assert!(callback_context.success, "DID Not Registered or Not Authorized!");
 
     if state.vcs.contains_key(&issuer_did) {
-        let mut vcs_map = state.vcs.get(&issuer_did).unwrap();
+        let mut vcs_map = state
+        .vcs
+        .get(&issuer_did)
+        .unwrap_or_else(|| panic!("No VC map for issuer {}", issuer_did));
         
         vcs_map.insert(state.next_vc_id, new_vc);
 
     } else {
         let mut vcs_map : SortedVecMap<u128, VC> = SortedVecMap::new();
         vcs_map.insert(state.next_vc_id, new_vc);
-        state.vcs.insert(issuer_did, vcs_map);
     }
-
+    
+    state.vcs.insert(issuer_did, vcs_map);
     state.next_vc_id += 1;
 
     (state, vec![])


### PR DESCRIPTION
This is to reduce the gas fee that results from increased computation while traversing the SortedVecMap as the map grows over each VC creation